### PR TITLE
Fix for Cordova/Ionic pch.h build errors re: issue 15

### DIFF
--- a/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.UWP/SQLite3.UWP.vcxproj
+++ b/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.UWP/SQLite3.UWP.vcxproj
@@ -119,7 +119,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>


### PR DESCRIPTION
The error(s) reported here: https://github.com/litehelpers/cordova-sqlite-ext/issues/15 are the result of the Debug Win32 UWP project trying to use precompiled headers. Changing line 122 from <PrecompiledHeader>Use</PrecompiledHeader> to <PrecompiledHeader>NotUsing</PrecompiledHeader> fixes this.
