### PR TITLE
Provide AppGroup directory as location for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ where the `iosDatabaseLocation` option may be set to one of the following choice
 - `default`: `Library/LocalDatabase` subdirectory - *NOT* visible to iTunes and *NOT* backed up by iCloud
 - `Library`: `Library` subdirectory - backed up by iCloud, *NOT* visible to iTunes
 - `Documents`: `Documents` subdirectory - visible to iTunes and backed up by iCloud
+- `Shared`: uses a shared directory depending on the app group specified in the `config.xml` with the preference `SqliteExtSharedGroupId`
 
 **WARNING:** Again, the new "default" iosDatabaseLocation value is *NOT* the same as the old default location and would break an upgrade for an app using the old default value (0) on iOS.
 

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ where the `iosDatabaseLocation` option may be set to one of the following choice
 - `default`: `Library/LocalDatabase` subdirectory - *NOT* visible to iTunes and *NOT* backed up by iCloud
 - `Library`: `Library` subdirectory - backed up by iCloud, *NOT* visible to iTunes
 - `Documents`: `Documents` subdirectory - visible to iTunes and backed up by iCloud
-- `Shared`: uses a shared directory depending on the app group specified in the `config.xml` with the preference `SqliteExtSharedGroupId`
+- `Shared`: uses a shared directory depending on the app group specified in the `config.xml` with the preference `SqliteExtAppGroupId` (something like 'group.de.company.GameContainer')
 
 **WARNING:** Again, the new "default" iosDatabaseLocation value is *NOT* the same as the old default location and would break an upgrade for an app using the old default value (0) on iOS.
 

--- a/README.md
+++ b/README.md
@@ -721,7 +721,6 @@ where the `iosDatabaseLocation` option may be set to one of the following choice
 - `default`: `Library/LocalDatabase` subdirectory - *NOT* visible to iTunes and *NOT* backed up by iCloud
 - `Library`: `Library` subdirectory - backed up by iCloud, *NOT* visible to iTunes
 - `Documents`: `Documents` subdirectory - visible to iTunes and backed up by iCloud
-- `Shared`: uses a shared directory depending on the app group specified in the `config.xml` with the preference `SqliteExtAppGroupId` (something like 'group.de.company.GameContainer')
 
 **WARNING:** Again, the new "default" iosDatabaseLocation value is *NOT* the same as the old default location and would break an upgrade for an app using the old default value (0) on iOS.
 

--- a/SQLitePlugin.coffee.md
+++ b/SQLitePlugin.coffee.md
@@ -607,6 +607,7 @@
       'default' : 'nosync'
       'Documents' : 'docs'
       'Library' : 'libs'
+      'Shared' : 'shared'
 
     SQLiteFactory =
       ###

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -282,7 +282,7 @@
 
         NSString *absoluteURL = [options objectForKey:@"iosDirectoryURL"];
         if (absoluteURL != NULL) {
-            dbname = absoluteURL;
+            dbPath = absoluteURL;
         }
 
         if ([[NSFileManager defaultManager]fileExistsAtPath:dbPath]) {

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -75,24 +75,6 @@
                 [appDBPaths setObject: libs forKey:@"nosync"];
             }
         }
-
-        NSString *groupId = [self.commandDelegate.settings objectForKey:[@"SqliteExtAppGroupId" lowercaseString]];
-        BOOL sharedFolderFound = NO;
-        NSUserDefaults *prefs = [[NSUserDefaults alloc] initWithSuiteName:groupId];
-        if(prefs != nil && groupId != nil) {
-            [prefs synchronize];
-            NSURL *containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupId];
-
-            if(containerURL != nil)
-            {
-                NSString* containerDirectory = [containerURL path];
-
-                if(containerDirectory != nil) {
-                    sharedFolderFound = YES;
-                    [appDBPaths setObject: containerDirectory forKey:@"shared"];
-                }
-            }
-        }
     }
 }
 
@@ -138,6 +120,10 @@
     // DLog(@"using db location: %@", dblocation);
 
     NSString *dbname = [self getDBPath:dbfilename at:dblocation];
+    NSString *absoluteURL = [options objectForKey:@"iosDirectoryURL"];
+    if (absoluteURL != NULL) {
+        dbname = absoluteURL;
+    }
 
     if (dbname == NULL) {
         // XXX NOT EXPECTED (INTERNAL ERROR - XXX TODO SIGNAL ERROR STATUS):
@@ -293,6 +279,11 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"You must specify database path"];
     } else {
         NSString *dbPath = [self getDBPath:dbFileName at:dblocation];
+
+        NSString *absoluteURL = [options objectForKey:@"iosDirectoryURL"];
+        if (absoluteURL != NULL) {
+            dbname = absoluteURL;
+        }
 
         if ([[NSFileManager defaultManager]fileExistsAtPath:dbPath]) {
             DLog(@"delete full db path: %@", dbPath);

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -88,6 +88,15 @@
     return dbPath;
 }
 
+-(id) getDBPath:(NSString *)dbFile inDirectory:(NSString *)directory {
+    if (dbFile == NULL || directory == NULL) {
+        return NULL;
+    }
+    
+    NSString *dbPath = [directory stringByAppendingPathComponent: dbFile];
+    return dbPath;
+}
+
 -(void)echoStringValue: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult * pluginResult = nil;
@@ -120,9 +129,9 @@
     // DLog(@"using db location: %@", dblocation);
 
     NSString *dbname = [self getDBPath:dbfilename at:dblocation];
-    NSString *absoluteURL = [options objectForKey:@"iosDirectoryURL"];
-    if (absoluteURL != NULL) {
-        dbname = absoluteURL;
+    NSString *directoryURL = [options objectForKey:@"iosDirectoryURL"];
+    if (directoryURL != NULL) {
+        dbname = [self getDBPath:dbfilename inDirectory:directoryURL];
     }
 
     if (dbname == NULL) {
@@ -279,10 +288,9 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"You must specify database path"];
     } else {
         NSString *dbPath = [self getDBPath:dbFileName at:dblocation];
-
-        NSString *absoluteURL = [options objectForKey:@"iosDirectoryURL"];
-        if (absoluteURL != NULL) {
-            dbPath = absoluteURL;
+        NSString *directoryURL = [options objectForKey:@"iosDirectoryURL"];
+        if (directoryURL != NULL) {
+            dbPath = [self getDBPath:dbFileName inDirectory:directoryURL];
         }
 
         if ([[NSFileManager defaultManager]fileExistsAtPath:dbPath]) {

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -75,6 +75,25 @@
                 [appDBPaths setObject: libs forKey:@"nosync"];
             }
         }
+
+        NSString *preferenceName = @"SqliteExtSharedGroupId";
+        NSString *groupId = [self.commandDelegate.settings objectForKey:[preferenceName lowercaseString]];
+        BOOL sharedFolderFound = NO;
+        NSUserDefaults *prefs = [[NSUserDefaults alloc] initWithSuiteName:groupId];
+        if(prefs != nil && groupId != nil) {
+            [prefs synchronize];
+            NSURL *containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupId];
+
+            if(containerURL != nil)
+            {
+                NSString* containerDirectory = [containerURL path];
+
+                if(containerDirectory != nil) {
+                    sharedFolderFound = YES;
+                    [appDBPaths setObject: containerDirectory forKey:@"shared"];
+                }
+            }
+        }
     }
 }
 

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -84,15 +84,14 @@
     }
 
     NSString *dbdir = [appDBPaths objectForKey:atkey];
-    NSString *dbPath = [dbdir stringByAppendingPathComponent: dbFile];
-    return dbPath;
+    return [self getDBPath:dbFile inDirectory:dbdir];
 }
 
 -(id) getDBPath:(NSString *)dbFile inDirectory:(NSString *)directory {
     if (dbFile == NULL || directory == NULL) {
         return NULL;
     }
-    
+
     NSString *dbPath = [directory stringByAppendingPathComponent: dbFile];
     return dbPath;
 }

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -76,8 +76,7 @@
             }
         }
 
-        NSString *preferenceName = @"SqliteExtSharedGroupId";
-        NSString *groupId = [self.commandDelegate.settings objectForKey:[preferenceName lowercaseString]];
+        NSString *groupId = [self.commandDelegate.settings objectForKey:[@"SqliteExtAppGroupId" lowercaseString]];
         BOOL sharedFolderFound = NO;
         NSUserDefaults *prefs = [[NSUserDefaults alloc] initWithSuiteName:groupId];
         if(prefs != nil && groupId != nil) {

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -627,8 +627,10 @@
         if (!dblocation) {
           throw newSQLError('Valid iOS database location could not be determined in deleteDatabase call');
         }
+        args.dblocation = dblocation;
+      } else {
+        args.iosDirectoryURL = first.iosDirectoryURL;
       }
-      args.dblocation = dblocation;
       delete SQLitePlugin.prototype.openDBs[args.path];
       return cordova.exec(success, error, "SQLitePlugin", "delete", [args]);
     }

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -546,7 +546,8 @@
   iosLocationMap = {
     'default': 'nosync',
     'Documents': 'docs',
-    'Library': 'libs'
+    'Library': 'libs',
+    'Shared': 'shared'
   };
 
   SQLiteFactory = {

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -546,8 +546,7 @@
   iosLocationMap = {
     'default': 'nosync',
     'Documents': 'docs',
-    'Library': 'libs',
-    'Shared': 'shared'
+    'Library': 'libs'
   };
 
   SQLiteFactory = {
@@ -570,8 +569,8 @@
       if (!openargs.name) {
         throw newSQLError('Database name value is missing in openDatabase call');
       }
-      if (!openargs.iosDatabaseLocation && !openargs.location && openargs.location !== 0) {
-        throw newSQLError('Database location or iosDatabaseLocation setting is now mandatory in openDatabase call.');
+      if (!openargs.iosDatabaseLocation && !openargs.location && openargs.location !== 0 && !openargs.iosDirectoryURL) {
+        throw newSQLError('Database location, iosDatabaseLocation or iosDirectoryURL setting is now mandatory in openDatabase call.');
       }
       if (!!openargs.location && !!openargs.iosDatabaseLocation) {
         throw newSQLError('AMBIGUOUS: both location and iosDatabaseLocation settings are present in openDatabase call. Please use either setting, not both.');
@@ -615,8 +614,8 @@
         }
         args.path = dbname;
       }
-      if (!first.iosDatabaseLocation && !first.location && first.location !== 0) {
-        throw newSQLError('Database location or iosDatabaseLocation setting is now mandatory in deleteDatabase call.');
+      if (!first.iosDatabaseLocation && !first.location && first.location !== 0 && !openargs.iosDirectoryURL) {
+        throw newSQLError('Database location, iosDatabaseLocation and iosDirectoryURL setting is now mandatory in deleteDatabase call.');
       }
       if (!!first.location && !!first.iosDatabaseLocation) {
         throw newSQLError('AMBIGUOUS: both location and iosDatabaseLocation settings are present in deleteDatabase call. Please use either setting value, not both.');

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -575,9 +575,11 @@
       if (!!openargs.location && !!openargs.iosDatabaseLocation) {
         throw newSQLError('AMBIGUOUS: both location and iosDatabaseLocation settings are present in openDatabase call. Please use either setting, not both.');
       }
-      dblocation = !!openargs.location && openargs.location === 'default' ? iosLocationMap['default'] : !!openargs.iosDatabaseLocation ? iosLocationMap[openargs.iosDatabaseLocation] : dblocations[openargs.location];
-      if (!dblocation) {
-        throw newSQLError('Valid iOS database location could not be determined in openDatabase call');
+      if (!openargs.iosDirectoryURL) {
+        dblocation = !!openargs.location && openargs.location === 'default' ? iosLocationMap['default'] : !!openargs.iosDatabaseLocation ? iosLocationMap[openargs.iosDatabaseLocation] : dblocations[openargs.location];
+        if (!dblocation) {
+          throw newSQLError('Valid iOS database location could not be determined in openDatabase call');
+        }
       }
       openargs.dblocation = dblocation;
       if (!!openargs.createFromLocation && openargs.createFromLocation === 1) {
@@ -614,15 +616,17 @@
         }
         args.path = dbname;
       }
-      if (!first.iosDatabaseLocation && !first.location && first.location !== 0 && !openargs.iosDirectoryURL) {
+      if (!first.iosDatabaseLocation && !first.location && first.location !== 0 && !first.iosDirectoryURL) {
         throw newSQLError('Database location, iosDatabaseLocation and iosDirectoryURL setting is now mandatory in deleteDatabase call.');
       }
       if (!!first.location && !!first.iosDatabaseLocation) {
         throw newSQLError('AMBIGUOUS: both location and iosDatabaseLocation settings are present in deleteDatabase call. Please use either setting value, not both.');
       }
-      dblocation = !!first.location && first.location === 'default' ? iosLocationMap['default'] : !!first.iosDatabaseLocation ? iosLocationMap[first.iosDatabaseLocation] : dblocations[first.location];
-      if (!dblocation) {
-        throw newSQLError('Valid iOS database location could not be determined in deleteDatabase call');
+      if (!first.iosDirectoryURL) {
+        dblocation = !!first.location && first.location === 'default' ? iosLocationMap['default'] : !!first.iosDatabaseLocation ? iosLocationMap[first.iosDatabaseLocation] : dblocations[first.location];
+        if (!dblocation) {
+          throw newSQLError('Valid iOS database location could not be determined in deleteDatabase call');
+        }
       }
       args.dblocation = dblocation;
       delete SQLitePlugin.prototype.openDBs[args.path];


### PR DESCRIPTION
This changes provide a new iOS Location called "Shared" which uses the AppGroup-ID to access a shared directory. If you set the `iosDatabaseLocation` to `Shared` and you set the preference `SqliteExtAppGroupId` in the `config.xml` to your AppGroup-ID, than the database can be used in the shared directory for your AppGroup.

I have to admit, that this is a very "fast" and simple way of adding this functionality, so I'm not sure if it's the right way. But it's working for me and I need it in a project.