### PR TITLE
Capacitor

### DIFF
--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -241,46 +241,60 @@ public class SQLitePlugin extends CordovaPlugin {
         // IMPLEMENTATION based on various sources:
         InputStream in = null;
         OutputStream out = null;
+        
+        /*
+     ** Different path variations for Cordova/Ionic, Capacitor
+     ** Capacitor writes the source to the public/assets path, but
+     ** some have an old code which copies the dataabse to the root: 'public'.
+     ** So we check for all different versions
+     */
+     
+        String[] pathArray = {"www/", "www/assets/", "public/", "public/assets/"};
 
-        try {
-            in = this.cordova.getActivity().getAssets().open("www/" + myDBName);
-            String dbPath = dbfile.getAbsolutePath();
-            dbPath = dbPath.substring(0, dbPath.lastIndexOf("/") + 1);
+        for (String resourcePath : pathArray) {
 
-            File dbPathFile = new File(dbPath);
-            if (!dbPathFile.exists())
-                dbPathFile.mkdirs();
+            try {
+                in = this.cordova.getActivity().getAssets().open(resourcePath + myDBName);
+                String dbPath = dbfile.getAbsolutePath();
+                dbPath = dbPath.substring(0, dbPath.lastIndexOf("/") + 1);
 
-            File newDbFile = new File(dbPath + myDBName);
-            out = new FileOutputStream(newDbFile);
+                File dbPathFile = new File(dbPath);
+                if (!dbPathFile.exists())
+                    dbPathFile.mkdirs();
 
-            // XXX TODO: this is very primitive, other alternatives at:
-            // http://www.journaldev.com/861/4-ways-to-copy-file-in-java
-            byte[] buf = new byte[1024];
-            int len;
-            while ((len = in.read(buf)) > 0)
-                out.write(buf, 0, len);
-    
-            Log.v("info", "Copied prepopulated DB content to: " + newDbFile.getAbsolutePath());
-        } catch (IOException e) {
-            Log.v("createFromResource", "No prepopulated DB found, Error=" + e.getMessage());
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                    Log.v("info", "Error closing input DB file, ignored");
+                File newDbFile = new File(dbPath + myDBName);
+                out = new FileOutputStream(newDbFile);
+
+                // XXX TODO: this is very primitive, other alternatives at:
+                // http://www.journaldev.com/861/4-ways-to-copy-file-in-java
+                byte[] buf = new byte[1024];
+                int len;
+                while ((len = in.read(buf)) > 0)
+                    out.write(buf, 0, len);
+
+                Log.v("info", "Copied prepopulated DB content from " + resourcePath + " to: " + newDbFile.getAbsolutePath());
+            } catch (IOException e) {
+                Log.v("createFromResource", "No prepopulated DB found in path " + resourcePath + ", Error=" + e.getMessage());
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException ignored) {
+                        Log.v("info", "Error closing input DB file, ignored");
+                    }
+                }
+
+                if (out != null) {
+                    try {
+                        out.close();
+                    } catch (IOException ignored) {
+                        Log.v("info", "Error closing output DB file, ignored");
+                    }
                 }
             }
-    
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ignored) {
-                    Log.v("info", "Error closing output DB file, ignored");
-                }
-            }
+
         }
+
     }
 
     /**

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -198,9 +198,8 @@
     // IMPLEMENTATION based on various sources:
     NSString * bundleRoot = [[NSBundle mainBundle] resourcePath];
 
-    NSString * public = [bundleRoot stringByAppendingPathComponent:@"public"];
-    NSString * assets = [public stringByAppendingPathComponent:@"assets"];
-    NSString * prepopulatedDb = [assets stringByAppendingPathComponent: dbfile];
+    NSString * www = [bundleRoot stringByAppendingPathComponent:@"www"];
+    NSString * prepopulatedDb = [www stringByAppendingPathComponent: dbfile];
     // NSLog(@"Look for pre-populated DB at: %@", prepopulatedDb);
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDb]) {

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -199,14 +199,48 @@
     NSString * bundleRoot = [[NSBundle mainBundle] resourcePath];
 
     NSString * www = [bundleRoot stringByAppendingPathComponent:@"www"];
+    NSString * wwwAssets = [www stringByAppendingPathComponent:@"assets"];
     NSString * prepopulatedDb = [www stringByAppendingPathComponent: dbfile];
+    NSString * prepopulatedDbAssets = [wwwAssets stringByAppendingPathComponent: dbfile];
     // NSLog(@"Look for pre-populated DB at: %@", prepopulatedDb);
+    
+    NSString * public = [bundleRoot stringByAppendingPathComponent:@"public"];
+    NSString * assets = [public stringByAppendingPathComponent:@"assets"];
+    NSString * publicDB = [public stringByAppendingPathComponent: dbfile];
+    NSString * assetsDB = [assets stringByAppendingPathComponent: dbfile];
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDb]) {
         NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
         NSError * error;
         BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDb toPath:dbname error:&error];
 
+        if(success)
+            NSLog(@"Copied pre-populated DB content to: %@", dbname);
+        else
+            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDbAssets]) {
+        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSError * error;
+        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDbAssets toPath:dbname error:&error];
+        
+        if(success)
+            NSLog(@"Copied pre-populated DB content to: %@", dbname);
+        else
+            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:publicDB]) {
+        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSError * error;
+        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:publicDB toPath:dbname error:&error];
+        
+        if(success)
+            NSLog(@"Copied pre-populated DB content to: %@", dbname);
+        else
+            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:assetsDB]) {
+        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSError * error;
+        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:assetsDB toPath:dbname error:&error];
+        
         if(success)
             NSLog(@"Copied pre-populated DB content to: %@", dbname);
         else

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -197,54 +197,40 @@
 -(void) createFromResource: (NSString *)dbfile withDbname:(NSString *)dbname {
     // IMPLEMENTATION based on various sources:
     NSString * bundleRoot = [[NSBundle mainBundle] resourcePath];
-
-    NSString * www = [bundleRoot stringByAppendingPathComponent:@"www"];
-    NSString * wwwAssets = [www stringByAppendingPathComponent:@"assets"];
-    NSString * prepopulatedDb = [www stringByAppendingPathComponent: dbfile];
-    NSString * prepopulatedDbAssets = [wwwAssets stringByAppendingPathComponent: dbfile];
-    // NSLog(@"Look for pre-populated DB at: %@", prepopulatedDb);
     
-    NSString * public = [bundleRoot stringByAppendingPathComponent:@"public"];
-    NSString * assets = [public stringByAppendingPathComponent:@"assets"];
-    NSString * publicDB = [public stringByAppendingPathComponent: dbfile];
-    NSString * assetsDB = [assets stringByAppendingPathComponent: dbfile];
-
-    if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDb]) {
-        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
-        NSError * error;
-        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDb toPath:dbname error:&error];
-
-        if(success)
-            NSLog(@"Copied pre-populated DB content to: %@", dbname);
-        else
-            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
-    } else if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDbAssets]) {
-        NSLog(@"Found prepopulated DB: %@", prepopulatedDbAssets);
-        NSError * error;
-        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDbAssets toPath:dbname error:&error];
+    /*
+     ** Different path variations for Cordova/Ionic, Capacitor
+     ** Capacitor writes the source to the public/assets path, but
+     ** some have an old code which copies the dataabse to the root: 'public'.
+     ** So we check for all different versions
+     */
+    
+    NSArray * pathArray = @[
+                            [bundleRoot stringByAppendingPathComponent:@"www"],
+                            [bundleRoot stringByAppendingPathComponent:@"www/assets"],
+                            [bundleRoot stringByAppendingPathComponent:@"public"],
+                            [bundleRoot stringByAppendingPathComponent:@"public/assets"]
+                            ];
+    
+    /*
+     ** Loop the paths from the pathArray for all possible variations in db locations
+     */
+    for (NSString *copyPath in pathArray) {
         
-        if(success)
-            NSLog(@"Copied pre-populated DB content to: %@", dbname);
-        else
-            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
-    } else if ([[NSFileManager defaultManager] fileExistsAtPath:publicDB]) {
-        NSLog(@"Found prepopulated DB: %@", publicDB);
-        NSError * error;
-        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:publicDB toPath:dbname error:&error];
         
-        if(success)
-            NSLog(@"Copied pre-populated DB content to: %@", dbname);
-        else
-            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
-    } else if ([[NSFileManager defaultManager] fileExistsAtPath:assetsDB]) {
-        NSLog(@"Found prepopulated DB: %@", assetsDB);
-        NSError * error;
-        BOOL success = [[NSFileManager defaultManager] copyItemAtPath:assetsDB toPath:dbname error:&error];
+        NSString *prepopulatedDb = [copyPath stringByAppendingPathComponent:dbfile];
         
-        if(success)
-            NSLog(@"Copied pre-populated DB content to: %@", dbname);
-        else
-            NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
+        
+        if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDb]) {
+            NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+            NSError * error;
+            BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDb toPath:dbname error:&error];
+            
+            if(success)
+                NSLog(@"Copied pre-populated DB content to: %@", dbname);
+            else
+                NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
+        }
     }
 }
 

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -219,7 +219,7 @@
         else
             NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
     } else if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDbAssets]) {
-        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSLog(@"Found prepopulated DB: %@", prepopulatedDbAssets);
         NSError * error;
         BOOL success = [[NSFileManager defaultManager] copyItemAtPath:prepopulatedDbAssets toPath:dbname error:&error];
         
@@ -228,7 +228,7 @@
         else
             NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
     } else if ([[NSFileManager defaultManager] fileExistsAtPath:publicDB]) {
-        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSLog(@"Found prepopulated DB: %@", publicDB);
         NSError * error;
         BOOL success = [[NSFileManager defaultManager] copyItemAtPath:publicDB toPath:dbname error:&error];
         
@@ -237,7 +237,7 @@
         else
             NSLog(@"Unable to copy pre-populated DB file: %@", [error localizedDescription]);
     } else if ([[NSFileManager defaultManager] fileExistsAtPath:assetsDB]) {
-        NSLog(@"Found prepopulated DB: %@", prepopulatedDb);
+        NSLog(@"Found prepopulated DB: %@", assetsDB);
         NSError * error;
         BOOL success = [[NSFileManager defaultManager] copyItemAtPath:assetsDB toPath:dbname error:&error];
         

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -198,8 +198,9 @@
     // IMPLEMENTATION based on various sources:
     NSString * bundleRoot = [[NSBundle mainBundle] resourcePath];
 
-    NSString * www = [bundleRoot stringByAppendingPathComponent:@"www"];
-    NSString * prepopulatedDb = [www stringByAppendingPathComponent: dbfile];
+    NSString * public = [bundleRoot stringByAppendingPathComponent:@"public"];
+    NSString * assets = [public stringByAppendingPathComponent:@"assets"];
+    NSString * prepopulatedDb = [assets stringByAppendingPathComponent: dbfile];
     // NSLog(@"Look for pre-populated DB at: %@", prepopulatedDb);
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:prepopulatedDb]) {


### PR DESCRIPTION
Added 3 more paths to the iOS CopyFromResource function to allow copy of pre-populated database from Ionic Capacitor folder structures.
The database resides in this folder structure under Public->dbname or Public->assets->dbname.